### PR TITLE
Add JWT Payload Decoding Functionality to AuthenticationHandler

### DIFF
--- a/Sources/Authentication/AuthenticationHandler.swift
+++ b/Sources/Authentication/AuthenticationHandler.swift
@@ -304,7 +304,7 @@ extension AuthenticationHandler: ASWebAuthenticationPresentationContextProviding
 
 
 extension AuthenticationHandler {
-    public static func getPayload(accessToken: String) <Payload: Decodable> -> Payload? {
+    public static func getPayload<Payload: Decodable>(accessToken: String)-> Payload? {
         let encodedData = { (string: String) -> Data? in
             var encodedString = string.replacingOccurrences(of: "-", with: "+").replacingOccurrences(of: "_", with: "/")
             

--- a/Sources/Authentication/AuthenticationHandler.swift
+++ b/Sources/Authentication/AuthenticationHandler.swift
@@ -304,7 +304,7 @@ extension AuthenticationHandler: ASWebAuthenticationPresentationContextProviding
 
 
 extension AuthenticationHandler {
-    public static func getPayload<Payload: Decodable>(accessToken: String)-> Payload? {
+    public static func getPayload<Payload: Decodable>(_ type: Payload.Type, accessToken: String)-> Payload? {
         let encodedData = { (string: String) -> Data? in
             var encodedString = string.replacingOccurrences(of: "-", with: "+").replacingOccurrences(of: "_", with: "/")
             

--- a/Sources/Authentication/AuthenticationHandler.swift
+++ b/Sources/Authentication/AuthenticationHandler.swift
@@ -303,8 +303,24 @@ extension AuthenticationHandler: ASWebAuthenticationPresentationContextProviding
 }
 
 
+/**
+ An extension for the `AuthenticationHandler` that provides a method to decode a JWT payload.
+
+ This extension provides a method `getPayload` that takes a decodable payload type and an access token as input.
+ The method returns an instance of the payload type, or `nil` if decoding fails.
+*/
 extension AuthenticationHandler {
+    /**
+     Decodes a JWT payload into a specified decodable type.
+     
+     - Parameters:
+        - type: The `Decodable` type to decode the payload into.
+        - accessToken: A JWT access token as a `String`.
+     
+     - Returns: An instance of the provided payload type, or `nil` if decoding fails.
+     */
     public func getPayload<Payload: Decodable>(_ type: Payload.Type, accessToken: String)-> Payload? {
+        // Helper function to decode base64URL encoded strings
         let encodedData = { (string: String) -> Data? in
             var encodedString = string.replacingOccurrences(of: "-", with: "+").replacingOccurrences(of: "_", with: "/")
             

--- a/Sources/Authentication/AuthenticationHandler.swift
+++ b/Sources/Authentication/AuthenticationHandler.swift
@@ -304,7 +304,7 @@ extension AuthenticationHandler: ASWebAuthenticationPresentationContextProviding
 
 
 extension AuthenticationHandler {
-    public static func getPayload<Payload: Decodable>(_ type: Payload.Type, accessToken: String)-> Payload? {
+    public func getPayload<Payload: Decodable>(_ type: Payload.Type, accessToken: String)-> Payload? {
         let encodedData = { (string: String) -> Data? in
             var encodedString = string.replacingOccurrences(of: "-", with: "+").replacingOccurrences(of: "_", with: "/")
             


### PR DESCRIPTION
[AB#55015](https://dev.azure.com/SKAT-DevOps/b3d2a59d-b60d-4d19-bcc1-b023099925ce/_workitems/edit/55015)
This PR introduces an extension to the AuthenticationHandler class, providing a method getPayload for decoding JWT payloads into a specified Decodable type. This method can be useful when dealing with JWT access tokens, as it allows easy extraction of the contained information in a type-safe manner.

The changes in this PR include:

1. The AuthenticationHandler extension with the getPayload method that takes a Decodable type and an access token as input, and returns an instance of the provided type or nil if decoding fails.
2. Documentation for the AuthenticationHandler extension and the getPayload method, explaining their purpose and usage.

With these changes, we can streamline the process of extracting information from JWT access tokens and improve the overall code quality by avoiding manual parsing and validation.