### PR TITLE
67848 Network URL Request builders

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -42,7 +42,7 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "Networking",
-            dependencies: [.product(name: "FirebaseCrashlytics", package: "firebase-ios-sdk")]),
+            dependencies: []),
         .testTarget(
             name: "NetworkingTests",
             dependencies: ["Networking"]),

--- a/Package.swift
+++ b/Package.swift
@@ -42,13 +42,13 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "Networking",
-            dependencies: []),
+            dependencies: [.product(name: "FirebaseCrashlytics", package: "firebase-ios-sdk")]),
         .testTarget(
             name: "NetworkingTests",
             dependencies: ["Networking"]),
         .target(
             name: "Authentication",
-            dependencies: ["SecurityHandler"]),
+            dependencies: ["SecurityHandler", "Networking",]),
         .target(
             name: "SecurityHandler",
             dependencies: [],

--- a/Sources/Authentication/Helpers/NetworkHelper.swift
+++ b/Sources/Authentication/Helpers/NetworkHelper.swift
@@ -63,16 +63,6 @@ func createTokenRequest(urlString: String, method: String, header: [String: Stri
     URLRequest.httpBody = body
     return URLRequest
 }
-func createUserRequest(urlString: String, method: String, header: [String: String]) throws -> URLRequest {
-    guard
-        let url = URL(string: urlString)
-    else { throw AuthenticationHandler.CustomError.invalidURL }
-    
-    var URLRequest = URLRequest(url: url)
-    URLRequest.httpMethod = method
-    URLRequest.allHTTPHeaderFields = header
-    return URLRequest
-}
 
 func createGetTokenBody(type: GetTokenType, configuration: AuthenticationHandler.Configuration, codeVerifier: String?) -> Data? {
         

--- a/Sources/Authentication/Internal dependencies/APIClientInterface.swift
+++ b/Sources/Authentication/Internal dependencies/APIClientInterface.swift
@@ -52,9 +52,9 @@ extension APIClient {
             
             switch automatedLoginModel.user {
             case .azure(let azureUser):
-                body = azureUser.asJsonData
+                body = azureUser.asRequestBody
             case .dcs(let dcsUser):
-                body = dcsUser.asJsonData
+                body = dcsUser.asRequestBody
             }
             
             let request = makePostRequest(url: URL(string: automatedLoginModel.url)!, requestBody: body)

--- a/Sources/Authentication/Models/JSON Input/AutomatedLoginAzureUser.swift
+++ b/Sources/Authentication/Models/JSON Input/AutomatedLoginAzureUser.swift
@@ -29,8 +29,7 @@ public struct AutomatedLoginAzureUser: Codable, Equatable, Identifiable, Hashabl
         case authorizations
     }
     
-    var asJsonData: Data? {
-        let encoder = JSONEncoder()
+    var asRequestBody: AuthenticationHandler.AutomatedLoginRequestBody {
         let body = AuthenticationHandler.AutomatedLoginRequestBody(
             apiKey: self.apiKey,
             clientID: self.clientID,
@@ -39,8 +38,7 @@ public struct AutomatedLoginAzureUser: Codable, Equatable, Identifiable, Hashabl
             azure: AuthenticationHandler.Azure(name: self.azure.name, email: self.azure.email),
             authorizations: AuthenticationHandler.AuthorizationsModel(roles: self.authorizations.roles)
         )
-        let jsonData = try? encoder.encode(body)
-        return jsonData
+        return body
     }
 }
 

--- a/Sources/Authentication/Models/JSON Input/AutomatedLoginAzureUser.swift
+++ b/Sources/Authentication/Models/JSON Input/AutomatedLoginAzureUser.swift
@@ -19,16 +19,6 @@ public struct AutomatedLoginAzureUser: Codable, Equatable, Identifiable, Hashabl
     let azure: Azure
     let authorizations: Authorizations
     
-    enum CodingKeys: String, CodingKey {
-        case title
-        case apiKey = "api-key"
-        case clientID = "client_id"
-        case azureOrDcs
-        case nonce
-        case azure
-        case authorizations
-    }
-    
     var asRequestBody: AuthenticationHandler.AutomatedLoginRequestBody {
         let body = AuthenticationHandler.AutomatedLoginRequestBody(
             apiKey: self.apiKey,
@@ -55,6 +45,16 @@ public struct AutomatedLoginAzureUser: Codable, Equatable, Identifiable, Hashabl
         self.nonce = nonce
         self.azure = azure
         self.authorizations = authorizations
+    }
+    
+    enum CodingKeys: String, CodingKey {
+        case title
+        case apiKey = "api-key"
+        case clientID = "client_id"
+        case azureOrDcs
+        case nonce
+        case azure
+        case authorizations
     }
 }
 

--- a/Sources/Authentication/Models/JSON Input/AutomatedLoginDCS.swift
+++ b/Sources/Authentication/Models/JSON Input/AutomatedLoginDCS.swift
@@ -29,8 +29,7 @@ public struct AutomatedLoginDCSUser: Codable, Equatable, Identifiable, Hashable 
         case authorizations
     }
     
-    var asJsonData: Data? {
-        let encoder = JSONEncoder()
+    var asRequestBody: AuthenticationHandler.AutomatedLoginRequestBody {
         let body = AuthenticationHandler.AutomatedLoginRequestBody(
             apiKey: self.apiKey,
             clientID: self.clientID,
@@ -63,8 +62,7 @@ public struct AutomatedLoginDCSUser: Codable, Equatable, Identifiable, Hashable 
                 countryCode: self.dcs.delegator.countryCode
             )
         )
-        let jsonData = try? encoder.encode(body)
-        return jsonData
+        return body
     }
 }
 

--- a/Sources/Networking/RequestBuilders.swift
+++ b/Sources/Networking/RequestBuilders.swift
@@ -18,6 +18,7 @@ import Foundation
 public func makeGetRequest(
     url: URL,
     parameters: [String: Any] = [:],
+    appID: String,
     headers: [String: String] = [:]
 ) -> URLRequest {
     var request: URLRequest
@@ -33,7 +34,7 @@ public func makeGetRequest(
         let escapedPlusChar = comps.url!.absoluteString.replacingOccurrences(of: "+", with: "%2B")
         request = .init(url: URL(string: escapedPlusChar)!)
     }
-    var requestWithDefaultHeaders = request.applyDefaultHeaders()
+    var requestWithDefaultHeaders = request.applyDefaultHeaders(appID: appID)
     requestWithDefaultHeaders.setValue("application/json", forHTTPHeaderField: "Content-Type")
     if !headers.isEmpty {
         var headerFields = requestWithDefaultHeaders.allHTTPHeaderFields ?? [:]
@@ -59,9 +60,10 @@ public func makePostRequest<Input: Encodable>(
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }(),
+    appID: String,
     headers: [String: String] = [:]
 ) -> URLRequest {
-    var request = URLRequest(url: url).applyDefaultHeaders()
+    var request = URLRequest(url: url).applyDefaultHeaders(appID: appID)
     request.httpMethod = "POST"
     request.httpBody = try! encoder.encode(requestBody)
     request.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -89,9 +91,10 @@ public func makeDeleteRequest<Input: Encodable>(
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }(),
+    appID: String,
     headers: [String: String] = [:]
 ) -> URLRequest {
-    var request = URLRequest(url: url).applyDefaultHeaders()
+    var request = URLRequest(url: url).applyDefaultHeaders(appID: appID)
     request.httpMethod = "DELETE"
     request.httpBody = try! encoder.encode(requestBody)
     request.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -119,9 +122,10 @@ public func makePutRequest<Input: Encodable>(
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }(),
+    appID: String,
     headers: [String: String] = [:]
 ) -> URLRequest {
-    var request = URLRequest(url: url).applyDefaultHeaders()
+    var request = URLRequest(url: url).applyDefaultHeaders(appID: appID)
     request.httpMethod = "PUT"
     request.httpBody = try! encoder.encode(requestBody)
     request.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -134,16 +138,18 @@ public func makePutRequest<Input: Encodable>(
 }
 
 private extension URLRequest {
-    func applyDefaultHeaders() -> URLRequest {
+    func applyDefaultHeaders(appID: String) -> URLRequest {
         var copy = self
         var headers = self.allHTTPHeaderFields ?? [:]
-        headers["x-request-id"] = UUID().uuidString
-        headers["x-platform"] = "iOS"
-        headers["x-version"] = Bundle.main.versionNumber
+        headers["X-App-ID"] = appID
+        headers["X-Request-ID"] = UUID().uuidString
+        headers["X-Platform"] = "iOS"
+        headers["X-App-Version"] = Bundle.main.versionNumber
         copy.allHTTPHeaderFields = headers
         return copy
     }
 }
+
 
 private extension Bundle {
     var versionNumber: String {

--- a/Sources/Networking/RequestBuilders.swift
+++ b/Sources/Networking/RequestBuilders.swift
@@ -7,10 +7,13 @@
 
 import Foundation
 
-/// Request builder
+/// Request for getting
+/// Per default a uiid and platform is in the header and if appVersion this parameter is also set in the header
 /// - Parameters:
 ///   - url: url + path to hit
 ///   - parameters: url query params
+///   - headers: extra heades
+///   - appVersion: App version, for example 1.2.4
 /// - Returns: Request
 
 public func makeGetRequest(
@@ -43,10 +46,13 @@ public func makeGetRequest(
 }
 
 /// Request for posting
+/// Per default a uiid and platform is in the header and if appVersion this parameter is also set in the header
 /// - Parameters:
 ///   - url: url + path to hit
 ///   - requestBody: the body to be encoded to json
 ///   - encoder: supply custom encoder if needed
+///   - headers: extra heades
+///   - appVersion: App version, for example 1.2.4
 /// - Returns: Request
 public func makePostRequest<Input: Encodable>(
     url: URL,
@@ -72,10 +78,13 @@ public func makePostRequest<Input: Encodable>(
 }
 
 /// Request for deleting
+/// Per default a uiid and platform is in the header and if appVersion this parameter is also set in the header
 /// - Parameters:
 ///   - url: url + path to hit
 ///   - requestBody: the body to be encoded to json
 ///   - encoder: supply custom encoder if needed
+///   - headers: extra heades
+///   - appVersion: App version, for example 1.2.4
 /// - Returns: Request
 public func makeDeleteRequest<Input: Encodable>(
     url: URL,
@@ -101,10 +110,13 @@ public func makeDeleteRequest<Input: Encodable>(
 }
 
 /// Request for updating
+/// Per default a uiid and platform is in the header and if appVersion this parameter is also set in the header
 /// - Parameters:
 ///   - url: url + path to hit
 ///   - requestBody: the body to be encoded to json
 ///   - encoder: supply custom encoder if needed
+///   - headers: extra heades
+///   - appVersion: App version, for example 1.2.4
 /// - Returns: Request
 public func makePutRequest<Input: Encodable>(
     url: URL,

--- a/Sources/Networking/RequestBuilders.swift
+++ b/Sources/Networking/RequestBuilders.swift
@@ -12,6 +12,7 @@ import Foundation
 /// - Parameters:
 ///   - url: url + path to hit
 ///   - parameters: url query params
+///   - appID: App Identifier. The idea is that it should be persisted locally on the phone so the same identifier will be sent even when closing the app and open again. The app client has the responsibility to handle that.
 ///   - headers: extra heades
 /// - Returns: Request
 
@@ -50,6 +51,7 @@ public func makeGetRequest(
 ///   - url: url + path to hit
 ///   - requestBody: the body to be encoded to json
 ///   - encoder: supply custom encoder if needed
+///   - appID: App Identifier. The idea is that it should be persisted locally on the phone so the same identifier will be sent even when closing the app and open again. The app client has the responsibility to handle that.
 ///   - headers: extra heades
 /// - Returns: Request
 public func makePostRequest<Input: Encodable>(
@@ -81,6 +83,7 @@ public func makePostRequest<Input: Encodable>(
 ///   - url: url + path to hit
 ///   - requestBody: the body to be encoded to json
 ///   - encoder: supply custom encoder if needed
+///   - appID: App Identifier. The idea is that it should be persisted locally on the phone so the same identifier will be sent even when closing the app and open again. The app client has the responsibility to handle that.
 ///   - headers: extra heades
 /// - Returns: Request
 public func makeDeleteRequest<Input: Encodable>(
@@ -112,6 +115,7 @@ public func makeDeleteRequest<Input: Encodable>(
 ///   - url: url + path to hit
 ///   - requestBody: the body to be encoded to json
 ///   - encoder: supply custom encoder if needed
+///   - appID: App Identifier. The idea is that it should be persisted locally on the phone so the same identifier will be sent even when closing the app and open again. The app client has the responsibility to handle that.
 ///   - headers: extra heades
 /// - Returns: Request
 public func makePutRequest<Input: Encodable>(

--- a/Sources/Networking/RequestBuilders.swift
+++ b/Sources/Networking/RequestBuilders.swift
@@ -19,7 +19,7 @@ import Foundation
 public func makeGetRequest(
     url: URL,
     parameters: [String: Any] = [:],
-    appID: String,
+    appID: String? = nil,
     headers: [String: String] = [:]
 ) -> URLRequest {
     var request: URLRequest
@@ -62,7 +62,7 @@ public func makePostRequest<Input: Encodable>(
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }(),
-    appID: String,
+    appID: String? = nil,
     headers: [String: String] = [:]
 ) -> URLRequest {
     var request = URLRequest(url: url).applyDefaultHeaders(appID: appID)
@@ -94,7 +94,7 @@ public func makeDeleteRequest<Input: Encodable>(
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }(),
-    appID: String,
+    appID: String? = nil,
     headers: [String: String] = [:]
 ) -> URLRequest {
     var request = URLRequest(url: url).applyDefaultHeaders(appID: appID)
@@ -126,7 +126,7 @@ public func makePutRequest<Input: Encodable>(
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }(),
-    appID: String,
+    appID: String? = nil,
     headers: [String: String] = [:]
 ) -> URLRequest {
     var request = URLRequest(url: url).applyDefaultHeaders(appID: appID)
@@ -142,10 +142,12 @@ public func makePutRequest<Input: Encodable>(
 }
 
 private extension URLRequest {
-    func applyDefaultHeaders(appID: String) -> URLRequest {
+    func applyDefaultHeaders(appID: String?) -> URLRequest {
         var copy = self
         var headers = self.allHTTPHeaderFields ?? [:]
-        headers["X-App-ID"] = appID
+        if let appID {
+            headers["X-App-ID"] = appID
+        }
         headers["X-Request-ID"] = UUID().uuidString
         headers["X-Platform"] = "iOS"
         headers["X-App-Version"] = Bundle.main.versionNumber

--- a/Sources/Networking/RequestBuilders.swift
+++ b/Sources/Networking/RequestBuilders.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// Request for getting
-/// Per default a uiid and platform is in the header and if appVersion this parameter is also set in the header
+/// Per default a uiid and platform is in the header and if appVersion is there it will also be in the header
 /// - Parameters:
 ///   - url: url + path to hit
 ///   - parameters: url query params
@@ -46,7 +46,7 @@ public func makeGetRequest(
 }
 
 /// Request for posting
-/// Per default a uiid and platform is in the header and if appVersion this parameter is also set in the header
+/// Per default a uiid and platform is in the header and if appVersion is there it will also be in the header
 /// - Parameters:
 ///   - url: url + path to hit
 ///   - requestBody: the body to be encoded to json
@@ -78,7 +78,7 @@ public func makePostRequest<Input: Encodable>(
 }
 
 /// Request for deleting
-/// Per default a uiid and platform is in the header and if appVersion this parameter is also set in the header
+/// Per default a uiid and platform is in the header and if appVersion is there it will also be in the header
 /// - Parameters:
 ///   - url: url + path to hit
 ///   - requestBody: the body to be encoded to json
@@ -110,7 +110,7 @@ public func makeDeleteRequest<Input: Encodable>(
 }
 
 /// Request for updating
-/// Per default a uiid and platform is in the header and if appVersion this parameter is also set in the header
+/// Per default a uiid and platform is in the header and if appVersion is there it will also be in the header
 /// - Parameters:
 ///   - url: url + path to hit
 ///   - requestBody: the body to be encoded to json

--- a/Sources/Networking/RequestBuilders.swift
+++ b/Sources/Networking/RequestBuilders.swift
@@ -146,11 +146,11 @@ private extension URLRequest {
         var copy = self
         var headers = self.allHTTPHeaderFields ?? [:]
         if let appID {
-            headers["X-App-ID"] = appID
+            headers["X-UFST-App-ID"] = appID
         }
-        headers["X-Request-ID"] = UUID().uuidString
-        headers["X-Platform"] = "iOS"
-        headers["X-App-Version"] = Bundle.main.versionNumber
+        headers["X-UFST-Request-ID"] = UUID().uuidString
+        headers["X-UFST-Platform"] = "iOS"
+        headers["X-UFST-App-Version"] = Bundle.main.versionNumber
         copy.allHTTPHeaderFields = headers
         return copy
     }

--- a/Sources/Networking/RequestBuilders.swift
+++ b/Sources/Networking/RequestBuilders.swift
@@ -1,0 +1,146 @@
+//
+//  File.swift
+//
+//
+//  Created by Nicolai Dam on 12/06/2023.
+//
+
+import Foundation
+
+/// Request builder
+/// - Parameters:
+///   - url: url + path to hit
+///   - parameters: url query params
+/// - Returns: Request
+
+public func makeGetRequest(
+    url: URL,
+    parameters: [String: Any] = [:],
+    headers: [String: String] = [:],
+    appVersion: String? = nil
+) -> URLRequest {
+    var request: URLRequest
+    if parameters.isEmpty {
+        request = URLRequest(url: url)
+    } else {
+        let items: [URLQueryItem] = parameters.map {
+            URLQueryItem(name: $0.key, value: "\($0.value)")
+        }
+        var comps = URLComponents(url: url, resolvingAgainstBaseURL: true)!
+        comps.queryItems = items
+
+        let escapedPlusChar = comps.url!.absoluteString.replacingOccurrences(of: "+", with: "%2B")
+        request = .init(url: URL(string: escapedPlusChar)!)
+    }
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.setValue(UUID().uuidString, forHTTPHeaderField: "x-request-id")
+    request.setValue("iOS", forHTTPHeaderField: "x-platform")
+    if let appVersion {
+        request.setValue(appVersion, forHTTPHeaderField: "x-version")
+    }
+    if !headers.isEmpty {
+        var headerFields = request.allHTTPHeaderFields ?? [:]
+        headerFields.merge(headers, uniquingKeysWith: { $1 })
+        request.allHTTPHeaderFields = headerFields
+    }
+    return request
+}
+
+/// Request for posting
+/// - Parameters:
+///   - url: url + path to hit
+///   - requestBody: the body to be encoded to json
+///   - encoder: supply custom encoder if needed
+/// - Returns: Request
+public func makePostRequest<Input: Encodable>(
+    url: URL,
+    requestBody: Input,
+    encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }(),
+    headers: [String: String] = [:],
+    appVersion: String? = nil
+) -> URLRequest {
+    var request = URLRequest(url: url)
+    request.httpMethod = "POST"
+    request.httpBody = try! encoder.encode(requestBody)
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.setValue(UUID().uuidString, forHTTPHeaderField: "x-request-id")
+    request.setValue("iOS", forHTTPHeaderField: "x-platform")
+    if let appVersion {
+        request.setValue(appVersion, forHTTPHeaderField: "x-version")
+    }
+    if !headers.isEmpty {
+        var headerFields = request.allHTTPHeaderFields ?? [:]
+        headerFields.merge(headers, uniquingKeysWith: { $1 })
+        request.allHTTPHeaderFields = headerFields
+    } 
+    return request
+}
+
+/// Request for deleting
+/// - Parameters:
+///   - url: url + path to hit
+///   - requestBody: the body to be encoded to json
+///   - encoder: supply custom encoder if needed
+/// - Returns: Request
+public func makeDeleteRequest<Input: Encodable>(
+    url: URL,
+    requestBody: Input,
+    encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }(),
+    headers: [String: String] = [:],
+    appVersion: String? = nil
+) -> URLRequest {
+    var request = URLRequest(url: url)
+    request.httpMethod = "DELETE"
+    request.httpBody = try! encoder.encode(requestBody)
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.setValue(UUID().uuidString, forHTTPHeaderField: "x-request-id")
+    request.setValue("iOS", forHTTPHeaderField: "x-platform")
+    if let appVersion {
+        request.setValue(appVersion, forHTTPHeaderField: "x-version")
+    }
+    if !headers.isEmpty {
+        var headerFields = request.allHTTPHeaderFields ?? [:]
+        headerFields.merge(headers, uniquingKeysWith: { $1 })
+        request.allHTTPHeaderFields = headerFields
+    }
+    return request
+}
+
+/// Request for updating
+/// - Parameters:
+///   - url: url + path to hit
+///   - requestBody: the body to be encoded to json
+///   - encoder: supply custom encoder if needed
+/// - Returns: Request
+public func makePutRequest<Input: Encodable>(
+    url: URL,
+    requestBody: Input,
+    encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }(),
+    headers: [String: String] = [:],
+    appVersion: String? = nil
+) -> URLRequest {
+    var request = URLRequest(url: url)
+    request.httpMethod = "PUT"
+    request.httpBody = try! encoder.encode(requestBody)
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.setValue(UUID().uuidString, forHTTPHeaderField: "x-request-id")
+    request.setValue("iOS", forHTTPHeaderField: "x-platform")
+    if !headers.isEmpty {
+        var headerFields = request.allHTTPHeaderFields ?? [:]
+        headerFields.merge(headers, uniquingKeysWith: { $1 })
+        request.allHTTPHeaderFields = headerFields
+    }
+    return request
+}

--- a/Sources/Networking/RequestBuilders.swift
+++ b/Sources/Networking/RequestBuilders.swift
@@ -13,14 +13,12 @@ import Foundation
 ///   - url: url + path to hit
 ///   - parameters: url query params
 ///   - headers: extra heades
-///   - appVersion: App version, for example 1.2.4
 /// - Returns: Request
 
 public func makeGetRequest(
     url: URL,
     parameters: [String: Any] = [:],
-    headers: [String: String] = [:],
-    appVersion: String? = nil
+    headers: [String: String] = [:]
 ) -> URLRequest {
     var request: URLRequest
     if parameters.isEmpty {
@@ -35,7 +33,7 @@ public func makeGetRequest(
         let escapedPlusChar = comps.url!.absoluteString.replacingOccurrences(of: "+", with: "%2B")
         request = .init(url: URL(string: escapedPlusChar)!)
     }
-    var requestWithDefaultHeaders = request.applyDefaultHeaders(appVersion)
+    var requestWithDefaultHeaders = request.applyDefaultHeaders()
     requestWithDefaultHeaders.setValue("application/json", forHTTPHeaderField: "Content-Type")
     if !headers.isEmpty {
         var headerFields = requestWithDefaultHeaders.allHTTPHeaderFields ?? [:]
@@ -52,7 +50,6 @@ public func makeGetRequest(
 ///   - requestBody: the body to be encoded to json
 ///   - encoder: supply custom encoder if needed
 ///   - headers: extra heades
-///   - appVersion: App version, for example 1.2.4
 /// - Returns: Request
 public func makePostRequest<Input: Encodable>(
     url: URL,
@@ -62,10 +59,9 @@ public func makePostRequest<Input: Encodable>(
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }(),
-    headers: [String: String] = [:],
-    appVersion: String? = nil
+    headers: [String: String] = [:]
 ) -> URLRequest {
-    var request = URLRequest(url: url).applyDefaultHeaders(appVersion)
+    var request = URLRequest(url: url).applyDefaultHeaders()
     request.httpMethod = "POST"
     request.httpBody = try! encoder.encode(requestBody)
     request.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -84,7 +80,6 @@ public func makePostRequest<Input: Encodable>(
 ///   - requestBody: the body to be encoded to json
 ///   - encoder: supply custom encoder if needed
 ///   - headers: extra heades
-///   - appVersion: App version, for example 1.2.4
 /// - Returns: Request
 public func makeDeleteRequest<Input: Encodable>(
     url: URL,
@@ -94,10 +89,9 @@ public func makeDeleteRequest<Input: Encodable>(
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }(),
-    headers: [String: String] = [:],
-    appVersion: String? = nil
+    headers: [String: String] = [:]
 ) -> URLRequest {
-    var request = URLRequest(url: url).applyDefaultHeaders(appVersion)
+    var request = URLRequest(url: url).applyDefaultHeaders()
     request.httpMethod = "DELETE"
     request.httpBody = try! encoder.encode(requestBody)
     request.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -116,7 +110,6 @@ public func makeDeleteRequest<Input: Encodable>(
 ///   - requestBody: the body to be encoded to json
 ///   - encoder: supply custom encoder if needed
 ///   - headers: extra heades
-///   - appVersion: App version, for example 1.2.4
 /// - Returns: Request
 public func makePutRequest<Input: Encodable>(
     url: URL,
@@ -126,10 +119,9 @@ public func makePutRequest<Input: Encodable>(
         encoder.dateEncodingStrategy = .iso8601
         return encoder
     }(),
-    headers: [String: String] = [:],
-    appVersion: String? = nil
+    headers: [String: String] = [:]
 ) -> URLRequest {
-    var request = URLRequest(url: url).applyDefaultHeaders(appVersion)
+    var request = URLRequest(url: url).applyDefaultHeaders()
     request.httpMethod = "PUT"
     request.httpBody = try! encoder.encode(requestBody)
     request.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -142,15 +134,19 @@ public func makePutRequest<Input: Encodable>(
 }
 
 private extension URLRequest {
-    func applyDefaultHeaders(_ appVersion: String?) -> URLRequest {
+    func applyDefaultHeaders() -> URLRequest {
         var copy = self
         var headers = self.allHTTPHeaderFields ?? [:]
         headers["x-request-id"] = UUID().uuidString
         headers["x-platform"] = "iOS"
-        if let appVersion {
-            headers["x-version"] = appVersion
-        }
+        headers["x-version"] = Bundle.main.versionNumber
         copy.allHTTPHeaderFields = headers
         return copy
+    }
+}
+
+public extension Bundle {
+    var versionNumber: String {
+        return infoDictionary?["CFBundleShortVersionString"] as? String ?? "-"
     }
 }

--- a/Sources/Networking/RequestBuilders.swift
+++ b/Sources/Networking/RequestBuilders.swift
@@ -145,7 +145,7 @@ private extension URLRequest {
     }
 }
 
-public extension Bundle {
+private extension Bundle {
     var versionNumber: String {
         return infoDictionary?["CFBundleShortVersionString"] as? String ?? "-"
     }

--- a/Sources/Networking/RequestBuilders.swift
+++ b/Sources/Networking/RequestBuilders.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// Request for getting
-/// Per default a uiid and platform is in the header and if appVersion is there it will also be in the header
+/// Per default a request id, app version platform is in the header for better logging on the backend
 /// - Parameters:
 ///   - url: url + path to hit
 ///   - parameters: url query params
@@ -44,7 +44,7 @@ public func makeGetRequest(
 }
 
 /// Request for posting
-/// Per default a uiid and platform is in the header and if appVersion is there it will also be in the header
+/// Per default a request id, app version platform is in the header for better logging on the backend
 /// - Parameters:
 ///   - url: url + path to hit
 ///   - requestBody: the body to be encoded to json
@@ -74,7 +74,7 @@ public func makePostRequest<Input: Encodable>(
 }
 
 /// Request for deleting
-/// Per default a uiid and platform is in the header and if appVersion is there it will also be in the header
+/// Per default a request id, app version platform is in the header for better logging on the backend
 /// - Parameters:
 ///   - url: url + path to hit
 ///   - requestBody: the body to be encoded to json
@@ -104,7 +104,7 @@ public func makeDeleteRequest<Input: Encodable>(
 }
 
 /// Request for updating
-/// Per default a uiid and platform is in the header and if appVersion is there it will also be in the header
+/// Per default a request id, app version platform is in the header for better logging on the backend
 /// - Parameters:
 ///   - url: url + path to hit
 ///   - requestBody: the body to be encoded to json

--- a/Tests/NetworkingTests/NetworkingTests.swift
+++ b/Tests/NetworkingTests/NetworkingTests.swift
@@ -1,11 +1,41 @@
 import XCTest
 @testable import Networking
 
-final class NetworkingTests: XCTestCase {
-    func testExample() {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct
-        // results.
-//        XCTAssertEqual(Networking().text, "Hello, World!")
+class NetworkingTests: XCTestCase {
+
+    func testMakeGetNoParams() throws {
+        let req = makeGetRequest(url: URL.init(string: "https://test.dk")!)
+        XCTAssertEqual(req.url, URL.init(string: "https://test.dk"))
+    }
+
+    func testMakeGetWithParams() throws {
+        let params: [String: Any] = [
+            "int": 1,
+            "double": 1.0
+        ]
+
+        let authHeader: [String: String] = ["Authorization": "Some token" ]
+
+        let req = makeGetRequest(url: URL.init(string: "https://test.dk")!, parameters: params, headers: authHeader)
+        XCTAssertEqual(req.url?.host, "test.dk")
+        XCTAssertEqual(req.httpMethod, "GET")
+        XCTAssertTrue(req.url!.query!.contains("int=1"))
+        XCTAssertTrue(req.url!.query!.contains("double=1.0"))
+        XCTAssertTrue(req.value(forHTTPHeaderField: authHeader.keys.first!)!.contains(authHeader.values.first!))
+    }
+
+    func testMakePost() throws {
+        struct Vehicle: Encodable {
+            var id: Int
+            var name: String
+        }
+        let encoder = JSONEncoder()
+        let mercedes = Vehicle(id: 1, name: "Mercedes 220d")
+        let resultBody = try encoder.encode(mercedes)
+        let authHeader: [String: String] = ["Authorization": "Some token" ]
+        let req = makePostRequest(url: URL.init(string: "https://test.dk")!, requestBody: mercedes, encoder: encoder, headers: authHeader)
+        XCTAssertEqual(req.httpBody, resultBody)
+        XCTAssertEqual(req.httpMethod, "POST")
+        XCTAssertTrue(req.value(forHTTPHeaderField: authHeader.keys.first!)!.contains(authHeader.values.first!))
     }
 }

--- a/Tests/NetworkingTests/NetworkingTests.swift
+++ b/Tests/NetworkingTests/NetworkingTests.swift
@@ -6,6 +6,9 @@ class NetworkingTests: XCTestCase {
     func testMakeGetNoParams() throws {
         let req = makeGetRequest(url: URL.init(string: "https://test.dk")!)
         XCTAssertEqual(req.url, URL.init(string: "https://test.dk"))
+        XCTAssertTrue(req.value(forHTTPHeaderField: "x-platform")!.contains("iOS"))
+        XCTAssertNotNil(req.value(forHTTPHeaderField: "x-version")!)
+        XCTAssertNotNil(req.value(forHTTPHeaderField: "x-request-id")!)
     }
 
     func testMakeGetWithParams() throws {
@@ -22,6 +25,9 @@ class NetworkingTests: XCTestCase {
         XCTAssertTrue(req.url!.query!.contains("int=1"))
         XCTAssertTrue(req.url!.query!.contains("double=1.0"))
         XCTAssertTrue(req.value(forHTTPHeaderField: authHeader.keys.first!)!.contains(authHeader.values.first!))
+        XCTAssertTrue(req.value(forHTTPHeaderField: "x-platform")!.contains("iOS"))
+        XCTAssertNotNil(req.value(forHTTPHeaderField: "x-version")!)
+        XCTAssertNotNil(req.value(forHTTPHeaderField: "x-request-id")!)
     }
 
     func testMakePost() throws {
@@ -37,5 +43,8 @@ class NetworkingTests: XCTestCase {
         XCTAssertEqual(req.httpBody, resultBody)
         XCTAssertEqual(req.httpMethod, "POST")
         XCTAssertTrue(req.value(forHTTPHeaderField: authHeader.keys.first!)!.contains(authHeader.values.first!))
+        XCTAssertTrue(req.value(forHTTPHeaderField: "x-platform")!.contains("iOS"))
+        XCTAssertNotNil(req.value(forHTTPHeaderField: "x-version")!)
+        XCTAssertNotNil(req.value(forHTTPHeaderField: "x-request-id")!)
     }
 }

--- a/Tests/NetworkingTests/NetworkingTests.swift
+++ b/Tests/NetworkingTests/NetworkingTests.swift
@@ -7,10 +7,10 @@ class NetworkingTests: XCTestCase {
         let appIdentifier = "AppIdentifier"
         let req = makeGetRequest(url: URL.init(string: "https://test.dk")!, appID: appIdentifier)
         XCTAssertEqual(req.url, URL.init(string: "https://test.dk"))
-        XCTAssertTrue(req.value(forHTTPHeaderField: "X-Platform")!.contains("iOS"))
-        XCTAssertNotNil(req.value(forHTTPHeaderField: "X-App-Version")!)
-        XCTAssertNotNil(req.value(forHTTPHeaderField: "X-Request-ID")!)
-        XCTAssertTrue(req.value(forHTTPHeaderField: "X-App-ID")!.contains(appIdentifier))
+        XCTAssertTrue(req.value(forHTTPHeaderField: "X-UFST-Platform")!.contains("iOS"))
+        XCTAssertNotNil(req.value(forHTTPHeaderField: "X-UFST-App-Version")!)
+        XCTAssertNotNil(req.value(forHTTPHeaderField: "X-UFST-Request-ID")!)
+        XCTAssertTrue(req.value(forHTTPHeaderField: "X-UFST-App-ID")!.contains(appIdentifier))
     }
 
     func testMakeGetWithParams() throws {
@@ -28,10 +28,10 @@ class NetworkingTests: XCTestCase {
         XCTAssertTrue(req.url!.query!.contains("int=1"))
         XCTAssertTrue(req.url!.query!.contains("double=1.0"))
         XCTAssertTrue(req.value(forHTTPHeaderField: authHeader.keys.first!)!.contains(authHeader.values.first!))
-        XCTAssertTrue(req.value(forHTTPHeaderField: "X-Platform")!.contains("iOS"))
-        XCTAssertNotNil(req.value(forHTTPHeaderField: "X-App-Version")!)
-        XCTAssertNotNil(req.value(forHTTPHeaderField: "X-Request-ID")!)
-        XCTAssertTrue(req.value(forHTTPHeaderField: "X-App-ID")!.contains(appIdentifier))
+        XCTAssertTrue(req.value(forHTTPHeaderField: "X-UFST-Platform")!.contains("iOS"))
+        XCTAssertNotNil(req.value(forHTTPHeaderField: "X-UFST-App-Version")!)
+        XCTAssertNotNil(req.value(forHTTPHeaderField: "X-UFST-Request-ID")!)
+        XCTAssertTrue(req.value(forHTTPHeaderField: "X-UFST-App-ID")!.contains(appIdentifier))
     }
 
     func testMakePost() throws {
@@ -48,9 +48,9 @@ class NetworkingTests: XCTestCase {
         XCTAssertEqual(req.httpBody, resultBody)
         XCTAssertEqual(req.httpMethod, "POST")
         XCTAssertTrue(req.value(forHTTPHeaderField: authHeader.keys.first!)!.contains(authHeader.values.first!))
-        XCTAssertTrue(req.value(forHTTPHeaderField: "X-Platform")!.contains("iOS"))
-        XCTAssertNotNil(req.value(forHTTPHeaderField: "X-App-Version")!)
-        XCTAssertNotNil(req.value(forHTTPHeaderField: "X-Request-id")!)
-        XCTAssertTrue(req.value(forHTTPHeaderField: "X-App-ID")!.contains(appIdentifier))
+        XCTAssertTrue(req.value(forHTTPHeaderField: "X-UFST-Platform")!.contains("iOS"))
+        XCTAssertNotNil(req.value(forHTTPHeaderField: "X-UFST-App-Version")!)
+        XCTAssertNotNil(req.value(forHTTPHeaderField: "X-UFST-Request-id")!)
+        XCTAssertTrue(req.value(forHTTPHeaderField: "X-UFST-App-ID")!.contains(appIdentifier))
     }
 }

--- a/Tests/NetworkingTests/NetworkingTests.swift
+++ b/Tests/NetworkingTests/NetworkingTests.swift
@@ -4,14 +4,17 @@ import XCTest
 class NetworkingTests: XCTestCase {
 
     func testMakeGetNoParams() throws {
-        let req = makeGetRequest(url: URL.init(string: "https://test.dk")!)
+        let appIdentifier = "AppIdentifier"
+        let req = makeGetRequest(url: URL.init(string: "https://test.dk")!, appID: appIdentifier)
         XCTAssertEqual(req.url, URL.init(string: "https://test.dk"))
-        XCTAssertTrue(req.value(forHTTPHeaderField: "x-platform")!.contains("iOS"))
-        XCTAssertNotNil(req.value(forHTTPHeaderField: "x-version")!)
-        XCTAssertNotNil(req.value(forHTTPHeaderField: "x-request-id")!)
+        XCTAssertTrue(req.value(forHTTPHeaderField: "X-Platform")!.contains("iOS"))
+        XCTAssertNotNil(req.value(forHTTPHeaderField: "X-App-Version")!)
+        XCTAssertNotNil(req.value(forHTTPHeaderField: "X-Request-ID")!)
+        XCTAssertTrue(req.value(forHTTPHeaderField: "X-App-ID")!.contains(appIdentifier))
     }
 
     func testMakeGetWithParams() throws {
+        let appIdentifier = "AppIdentifier"
         let params: [String: Any] = [
             "int": 1,
             "double": 1.0
@@ -19,18 +22,20 @@ class NetworkingTests: XCTestCase {
 
         let authHeader: [String: String] = ["Authorization": "Some token" ]
 
-        let req = makeGetRequest(url: URL.init(string: "https://test.dk")!, parameters: params, headers: authHeader)
+        let req = makeGetRequest(url: URL.init(string: "https://test.dk")!, parameters: params, appID: appIdentifier, headers: authHeader)
         XCTAssertEqual(req.url?.host, "test.dk")
         XCTAssertEqual(req.httpMethod, "GET")
         XCTAssertTrue(req.url!.query!.contains("int=1"))
         XCTAssertTrue(req.url!.query!.contains("double=1.0"))
         XCTAssertTrue(req.value(forHTTPHeaderField: authHeader.keys.first!)!.contains(authHeader.values.first!))
-        XCTAssertTrue(req.value(forHTTPHeaderField: "x-platform")!.contains("iOS"))
-        XCTAssertNotNil(req.value(forHTTPHeaderField: "x-version")!)
-        XCTAssertNotNil(req.value(forHTTPHeaderField: "x-request-id")!)
+        XCTAssertTrue(req.value(forHTTPHeaderField: "X-Platform")!.contains("iOS"))
+        XCTAssertNotNil(req.value(forHTTPHeaderField: "X-App-Version")!)
+        XCTAssertNotNil(req.value(forHTTPHeaderField: "X-Request-ID")!)
+        XCTAssertTrue(req.value(forHTTPHeaderField: "X-App-ID")!.contains(appIdentifier))
     }
 
     func testMakePost() throws {
+        let appIdentifier = "AppIdentifier"
         struct Vehicle: Encodable {
             var id: Int
             var name: String
@@ -39,12 +44,13 @@ class NetworkingTests: XCTestCase {
         let mercedes = Vehicle(id: 1, name: "Mercedes 220d")
         let resultBody = try encoder.encode(mercedes)
         let authHeader: [String: String] = ["Authorization": "Some token" ]
-        let req = makePostRequest(url: URL.init(string: "https://test.dk")!, requestBody: mercedes, encoder: encoder, headers: authHeader)
+        let req = makePostRequest(url: URL.init(string: "https://test.dk")!, requestBody: mercedes, encoder: encoder, appID: appIdentifier, headers: authHeader)
         XCTAssertEqual(req.httpBody, resultBody)
         XCTAssertEqual(req.httpMethod, "POST")
         XCTAssertTrue(req.value(forHTTPHeaderField: authHeader.keys.first!)!.contains(authHeader.values.first!))
-        XCTAssertTrue(req.value(forHTTPHeaderField: "x-platform")!.contains("iOS"))
-        XCTAssertNotNil(req.value(forHTTPHeaderField: "x-version")!)
-        XCTAssertNotNil(req.value(forHTTPHeaderField: "x-request-id")!)
+        XCTAssertTrue(req.value(forHTTPHeaderField: "X-Platform")!.contains("iOS"))
+        XCTAssertNotNil(req.value(forHTTPHeaderField: "X-App-Version")!)
+        XCTAssertNotNil(req.value(forHTTPHeaderField: "X-Request-id")!)
+        XCTAssertTrue(req.value(forHTTPHeaderField: "X-App-ID")!.contains(appIdentifier))
     }
 }


### PR DESCRIPTION
We use the same request helpers in Dagebevis, Ejerskifte and Logbog so i thought it would make sense to have it in the shared library. 

One of the pro's of having the request builders in the shared lib is that we can easily adjust default headers, for example i added app version, platform and request id.

I updated the AuthenticationHandler to we use the helpers in there. 