### PR TITLE
Set TrackEventInput in Mixpanel client to public

### DIFF
--- a/Sources/Tracking/MixpanelClient.swift
+++ b/Sources/Tracking/MixpanelClient.swift
@@ -76,9 +76,9 @@ public struct MixPanelClient {
 }
 
 public struct TrackEventInput {
-    let event: EventTrigger
-    let screenIdentifier: String?
-    let extraProperties: [String: AnyObject]?
+    public let event: EventTrigger
+    public let screenIdentifier: String?
+    public let extraProperties: [String: AnyObject]?
     
     public init(event: EventTrigger, screenIdentifier: String? = nil, extraProperties: [String : AnyObject]? = nil) {
         self.event = event


### PR DESCRIPTION
Set TrackEventInput variables to public so it is possible implement helpers using the vars in the struct.